### PR TITLE
Remove hardcoded camera calibration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update \
         python3-pip \
         python3-vcstool \
     && pip install --no-cache-dir mcap pandas colorama \
-        segments-ai awscli boto3 \
+        segments-ai awscli boto3 scipy \
     && pip install --no-cache-dir --upgrade setuptools pip \
     && rm -rf /var/lib/apt/lists/*
 

--- a/scripts/labelling_preproc/add_segmentsai_sample.py
+++ b/scripts/labelling_preproc/add_segmentsai_sample.py
@@ -29,9 +29,6 @@ class SegmentsSampleCreator:
         # Initialise Segments.ai client
         self.client = SegmentS3Client(api_key)
 
-        # Initialise Frame creator
-        self.frame_creator = SensorFrameCreator()
-
     def add(
         self, dataset_name: str, sequence_name: str, local_data_directory: Path
     ):
@@ -81,6 +78,12 @@ class SegmentsSampleCreator:
         cameras_frames = {}
         for cam_id in camera_ids_list:
             cameras_frames[cam_id] = []
+
+        # Use the first sync frame to get information about the cameras
+        cameras_info = sync_key_frames[0]['cameras']
+        self.frame_creator = SensorFrameCreator(
+            local_data_directory, cameras_info
+        )
 
         print('Creating sensor sequences samples...')
         # Iterate over synchronised key frames
@@ -133,7 +136,7 @@ class SegmentsSampleCreator:
             dataset_name, sequence_name, multi_sensor_sequence
         )
 
-        print('Done \U00002714')
+        print('Done ✅')
 
 
 def main():

--- a/scripts/labelling_preproc/common/camera_calibration_parser.py
+++ b/scripts/labelling_preproc/common/camera_calibration_parser.py
@@ -10,7 +10,7 @@ class Intrinsics:
     Pinhole camera intrinsic values
 
     fx, fy: focal length in pixels
-    cx, cy: offsets (in pixels) ofgit stat the principal point
+    cx, cy: offsets (in pixels) of the principal point
             from the top-left corner of the image
     """
 
@@ -65,12 +65,18 @@ class CameraCalibrationParser:
         Parse the camera matrix and return the intrinsic values.
 
         Args:
-            camera_matrix (dict): Dictionary containing the 'data' list with intrinsic values.
+            camera_matrix (dict): Dictionary containing a 'data' key with a flat list
+                of 9 elements representing the 3x3 intrinsic matrix in row-major order:
+                [fx, 0, cx,
+                 0, fy, cy,
+                 0,  0, 1 ], where:
+                 -fx, fy: focal lengths in pixels.
+                 -cx, cy: offsets (in pixels) of the principal point
+                          from the top-left corner of the image.
 
         Returns:
             Intrinsics: Parsed intrinsic parameters.
         """
-        # data = [fx, 0, cx, 0, fy, cy, 0, 0, 1]
         fx = camera_matrix['data'][0]
         cx = camera_matrix['data'][2]
         fy = camera_matrix['data'][4]
@@ -82,12 +88,15 @@ class CameraCalibrationParser:
         Parse the distortion coefficients and return the distortion values.
 
         Args:
-            distortion_coeffs (dict): Dictionary containing the 'data' list with distortion values.
+            distortion_coeffs (dict): Dictionary containing a 'data' key with a
+                list of 5 values in the following order:
+                [k1, k2, p1, p2, k3], where:
+                - k1, k2, k3: radial distortion coefficients.
+                - p1, p2: tangential distortion coefficients.
 
         Returns:
             Distortion: Parsed distortion parameters.
         """
-        # data = [k1, k2, t1, t2, k3]
         k1 = distortion_coeffs['data'][0]
         k2 = distortion_coeffs['data'][1]
         p1 = distortion_coeffs['data'][2]

--- a/scripts/labelling_preproc/common/camera_calibration_parser.py
+++ b/scripts/labelling_preproc/common/camera_calibration_parser.py
@@ -1,0 +1,126 @@
+"""Camera calibration parser."""
+
+import yaml
+from dataclasses import dataclass
+
+
+@dataclass
+class Intrinsics:
+    """
+    Pinhole camera intrinsic values
+
+    fx, fy: focal length in pixels
+    cx, cy: offsets (in pixels) ofgit stat the principal point
+            from the top-left corner of the image
+    """
+
+    fx: float
+    fy: float
+    cx: float
+    cy: float
+
+
+@dataclass
+class Distortion:
+    """
+    Brown-Conrady distortion coefficients
+
+    k1, k2, k3: radial distortion coefficients
+    p1, p2: tangential distortion coefficients
+    """
+
+    model: str
+    k1: float
+    k2: float
+    k3: float
+    p1: float
+    p2: float
+
+
+@dataclass
+class CameraCalibrationData:
+    """
+    Camera calibration data
+
+    frame_id: camera frame id
+    intrinsics: camera intrinsic values
+    distortion: camera distortion coefficients
+    """
+
+    frame_id: str
+    intrinsics: Intrinsics
+    distortion: Distortion
+
+
+class CameraCalibrationParser:
+    """
+    Camera calibration params parser
+    """
+
+    def __init__(self):
+        pass
+
+    def get_intrinsics(self, camera_matrix: dict) -> Intrinsics:
+        """
+        Parse the camera matrix and return the intrinsic values.
+
+        Args:
+            camera_matrix (dict): Dictionary containing the 'data' list with intrinsic values.
+
+        Returns:
+            Intrinsics: Parsed intrinsic parameters.
+        """
+        # data = [fx, 0, cx, 0, fy, cy, 0, 0, 1]
+        fx = camera_matrix['data'][0]
+        cx = camera_matrix['data'][2]
+        fy = camera_matrix['data'][4]
+        cy = camera_matrix['data'][5]
+        return Intrinsics(fx, fy, cx, cy)
+
+    def get_distortion(self, distortion_coeffs: dict) -> Distortion:
+        """
+        Parse the distortion coefficients and return the distortion values.
+
+        Args:
+            distortion_coeffs (dict): Dictionary containing the 'data' list with distortion values.
+
+        Returns:
+            Distortion: Parsed distortion parameters.
+        """
+        # data = [k1, k2, t1, t2, k3]
+        k1 = distortion_coeffs['data'][0]
+        k2 = distortion_coeffs['data'][1]
+        p1 = distortion_coeffs['data'][2]
+        p2 = distortion_coeffs['data'][3]
+        k3 = distortion_coeffs['data'][4]
+        return Distortion('brown-conrady', k1, k2, k3, p1, p2)
+
+    def get_camera_calibration(
+        self, camera_calibration_file: str
+    ) -> CameraCalibrationData:
+        """
+        Parse the camera intrinsics file and return the calibration data.
+
+        Args:
+            camera_calibration_file (str): Path to the YAML file containing camera calibration parameters.
+
+        Returns:
+            CameraCalibrationData: Full calibration data including frame ID, intrinsics, and distortion.
+
+        Raises:
+            FileNotFoundError: If the YAML file does not exist.
+            KeyError: If expected keys are missing in the YAML data.
+            yaml.YAMLError: If the YAML content is invalid.
+        """
+        with open(camera_calibration_file) as yaml_file:
+            camera_calibration = yaml.safe_load(yaml_file)
+
+            intrinsics = self.get_intrinsics(
+                camera_calibration['camera_matrix']
+            )
+            distortion = self.get_distortion(
+                camera_calibration['distortion_coefficients']
+            )
+
+            frame_id = camera_calibration['camera_frame_id']
+            return CameraCalibrationData(frame_id, intrinsics, distortion)

--- a/scripts/labelling_preproc/common/sample_formats.py
+++ b/scripts/labelling_preproc/common/sample_formats.py
@@ -7,6 +7,16 @@ sensor_sequence_struct = {'name': '', 'task_type': '', 'attributes': {}}
 # Do not modify unless you know what you are doing!
 camera_ids_list = ['fsp_l', 'rsp_l', 'lspf_r', 'lspr_l', 'rspf_l', 'rspr_r']
 
+# Cameras' position in Segments.ai grid
+camera_grid_positions = {
+    'fsp_l': {'row': 0, 'col': 1},
+    'rsp_l': {'row': 1, 'col': 1},
+    'lspf_r': {'row': 0, 'col': 0},
+    'lspr_l': {'row': 1, 'col': 0},
+    'rspf_l': {'row': 0, 'col': 2},
+    'rspr_r': {'row': 1, 'col': 2},
+}
+
 # Image sample dictionary structure
 image_struct = {'image': {'url': ''}, 'name': ''}
 
@@ -35,184 +45,31 @@ pcd_struct = {
     'timestamp': 0,
 }
 
-# FIXME: Create all these structs from a file (see #3)
-
-# Front camera dictionary structure
-fsp_l_struct = {
+camera_image_struct = {
     "url": "image_url",
     "row": 0,  # Row when displaying multiple camera images
-    "col": 1,  # Col when displaying multiple camera images
+    "col": 0,  # Col when displaying multiple camera images
     "intrinsics": {
         "intrinsic_matrix": [
-            [1451.49531, 0.0, 1218.93228],
-            [0.0, 1450.7118, 683.50771],
-            [0.0, 0.0, 1.0],
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
         ]
     },
     "extrinsics": {
-        "translation": {"x": 0.660, "y": 0.316, "z": -0.275},
-        "rotation": {"qx": 0.518, "qy": -0.515, "qz": 0.486, "qw": -0.480},
+        "translation": {"x": 0, "y": 0, "z": 0},
+        "rotation": {"qx": 0, "qy": 0, "qz": 0, "qw": 0},
     },
     "distortion": {
         "model": "brown-conrady",
         "coefficients": {
-            "k1": -0.01423,
-            "k2": 0.03806,
-            "k3": 0.0,
-            "p1": -0.00111,
-            "p2": 0.00149,
+            "k1": 0,
+            "k2": 0,
+            "k3": 0,
+            "p1": 0,
+            "p2": 0,
         },
     },
     "camera_convention": "OpenCV",
     "name": "camera_fsp_l",
-}
-
-# Front camera dictionary structure
-rsp_l_struct = {
-    "url": "image_url",
-    "row": 1,  # Row when displaying multiple camera images
-    "col": 1,  # Col when displaying multiple camera images
-    "intrinsics": {
-        "intrinsic_matrix": [
-            [1453.84541, 0.0, 1196.47476],
-            [0.0, 1452.87508, 674.82694],
-            [0.0, 0.0, 1.0],
-        ]
-    },
-    "extrinsics": {
-        "translation": {"x": -0.530, "y": -0.282, "z": -0.217},
-        "rotation": {"qx": 0.523, "qy": 0.526, "qz": -0.475, "qw": -0.474},
-    },
-    "distortion": {
-        "model": "brown-conrady",
-        "coefficients": {
-            "k1": -0.01765,
-            "k2": 0.04014,
-            "k3": 0.0,
-            "p1": -0.00211,
-            "p2": 0.00385,
-        },
-    },
-    "camera_convention": "OpenCV",
-    "name": "camera_rsp_l",
-}
-
-# Front camera dictionary structure
-lspf_r_struct = {
-    "url": "image_url",
-    "row": 0,  # Row when displaying multiple camera images
-    "col": 0,  # Col when displaying multiple camera images
-    "intrinsics": {
-        "intrinsic_matrix": [
-            [1444.38913, 0.0, 1162.88551],
-            [0.0, 1442.8811, 716.39319],
-            [0.0, 0.0, 1.0],
-        ]
-    },
-    "extrinsics": {
-        "translation": {"x": 0.011, "y": 0.557, "z": -0.224},
-        "rotation": {"qx": -0.723, "qy": 0.149, "qz": -0.143, "qw": 0.659},
-    },
-    "distortion": {
-        "model": "brown-conrady",
-        "coefficients": {
-            "k1": -0.02565,
-            "k2": 0.04315,
-            "k3": 0.0,
-            "p1": 0.00124,
-            "p2": 0.00201,
-        },
-    },
-    "camera_convention": "OpenCV",
-    "name": "camera_lspf_r",
-}
-
-# Front camera dictionary structure
-lspr_l_struct = {
-    "url": "image_url",
-    "row": 1,  # Row when displaying multiple camera images
-    "col": 0,  # Col when displaying multiple camera images
-    "intrinsics": {
-        "intrinsic_matrix": [
-            [1465.059, 0.0, 1171.9781],
-            [0.0, 1464.79803, 666.8666],
-            [0.0, 0.0, 1.0],
-        ]
-    },
-    "extrinsics": {
-        "translation": {"x": -0.324, "y": 0.513, "z": -0.224},
-        "rotation": {"qx": -0.722, "qy": -0.161, "qz": 0.140, "qw": 0.658},
-    },
-    "distortion": {
-        "model": "brown-conrady",
-        "coefficients": {
-            "k1": -0.03082,
-            "k2": 0.0505,
-            "k3": 0.0,
-            "p1": -0.00112,
-            "p2": 0.00179,
-        },
-    },
-    "camera_convention": "OpenCV",
-    "name": "camera_lspr_l",
-}
-
-# Front camera dictionary structure
-rspf_l_struct = {
-    "url": "image_url",
-    "row": 0,  # Row when displaying multiple camera images
-    "col": 2,  # Col when displaying multiple camera images
-    "intrinsics": {
-        "intrinsic_matrix": [
-            [1461.55571, 0.0, 1224.79388],
-            [0.0, 1460.11652, 698.92044],
-            [0.0, 0.0, 1.0],
-        ]
-    },
-    "extrinsics": {
-        "translation": {"x": 0.032, "y": -0.523, "z": -0.214},
-        "rotation": {"qx": -0.149, "qy": 0.719, "qz": -0.663, "qw": 0.149},
-    },
-    "distortion": {
-        "model": "brown-conrady",
-        "coefficients": {
-            "k1": -0.02165,
-            "k2": 0.04774,
-            "k3": 0.0,
-            "p1": -0.00045,
-            "p2": -0.00174,
-        },
-    },
-    "camera_convention": "OpenCV",
-    "name": "camera_rspf_l",
-}
-
-# Front camera dictionary structure
-rspr_r_struct = {
-    "url": "image_url",
-    "row": 1,  # Row when displaying multiple camera images
-    "col": 2,  # Col when displaying multiple camera images
-    "intrinsics": {
-        "intrinsic_matrix": [
-            [1447.00739, 0.0, 1213.12424],
-            [0.0, 1447.20673, 686.80094],
-            [0.0, 0.0, 1.0],
-        ]
-    },
-    "extrinsics": {
-        "translation": {"x": -0.329, "y": -0.551, "z": -0.214},
-        "rotation": {"qx": 0.162, "qy": 0.723, "qz": -0.659, "qw": -0.134},
-    },
-    "distortion": {
-        "model": "brown-conrady",
-        "coefficients": {
-            "k1": -0.02134,
-            "k2": 0.04395,
-            "k3": 0.0,
-            "p1": -0.00182,
-            "p2": 0.0,
-        },
-    },
-    "camera_convention": "OpenCV",
-    "name": "camera_rspr_r",
 }

--- a/scripts/labelling_preproc/common/sensor_frame_ceator.py
+++ b/scripts/labelling_preproc/common/sensor_frame_ceator.py
@@ -24,7 +24,7 @@ from labelling_preproc.common.utils import file_exists
 @dataclass
 class CameraData:
     """
-    Camera data.
+    Holds camera calibration and extrinsic transform data.
     """
 
     calibration_data: CameraCalibrationData

--- a/scripts/labelling_preproc/common/sensor_frame_ceator.py
+++ b/scripts/labelling_preproc/common/sensor_frame_ceator.py
@@ -1,22 +1,75 @@
 #!/usr/bin/python3
+import copy
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+from labelling_preproc.common.camera_calibration_parser import (
+    CameraCalibrationParser,
+    CameraCalibrationData,
+)
+from labelling_preproc.common.transform_tree import TransformTree, Transform
 
 from labelling_preproc.common.sample_formats import (
     image_struct,
     pcd_struct,
-    fsp_l_struct,
-    rsp_l_struct,
-    lspf_r_struct,
-    lspr_l_struct,
-    rspf_l_struct,
-    rspr_r_struct,
+    camera_image_struct,
+    camera_grid_positions,
 )
+
+from labelling_preproc.common.utils import file_exists
+
+
+@dataclass
+class CameraData:
+    """
+    Camera data.
+    """
+
+    calibration_data: CameraCalibrationData
+    extrinsics: Transform
 
 
 class SensorFrameCreator:
 
-    def __init__(self):
+    def __init__(self, data_directory: Path, cameras_info: list):
+        self.data_directory = data_directory
         # Based on vehicle's TF tree
         self.GROUND_Z_OFFSET_BELOW_LIDAR_M = -1.78
+
+        # Load the transform tree from the transforms.yaml file
+        transforms_file = data_directory / 'extrinsics/transforms.yaml'
+        file_exists(transforms_file)
+        self.transform_tree = TransformTree(str(transforms_file))
+        self.camera_calibration_parser = CameraCalibrationParser()
+        self.cameras_data = {}
+
+        self.LIDAR_FRAME_ID = 'lidar_ouster_top'
+
+        self.get_cameras_calibration(cameras_info)
+
+    def get_cameras_calibration(self, cameras_info: list):
+
+        for camera in cameras_info:
+            camera_name = camera['name']
+            calibration_file = (
+                self.data_directory
+                / 'camera'
+                / camera_name
+                / 'camera_calibration.yaml'
+            )
+            calibration_data = (
+                self.camera_calibration_parser.get_camera_calibration(
+                    str(calibration_file)
+                )
+            )
+            transform = self.transform_tree.get_transform(
+                self.LIDAR_FRAME_ID, calibration_data.frame_id
+            )
+            self.cameras_data[camera_name] = CameraData(
+                calibration_data=calibration_data, extrinsics=transform
+            )
 
     def create_3dpointcloud_frame(
         self, idx, sync_key_frame, assets_meta, ego_poses
@@ -61,48 +114,48 @@ class SensorFrameCreator:
 
         return image_frame
 
-    def get_cam_url(self, camera_name, cameras_list, assets_meta):
-
-        cam_id = None
-        for camera in cameras_list:
-            if camera['name'] == camera_name:
-                cam_id = camera['global_id']
-
-        if cam_id is None:
-            return 'S3 url not found!'
-
-        return assets_meta[str(cam_id)]['s3_url']
-
     def get_images(self, sync_key_frame, assets_meta):
+        images = []
+        for cam in sync_key_frame['cameras']:
+            name = cam['name']
+            global_id = cam['global_id']
+            camera_image = camera_image_struct
+            camera_image['url'] = assets_meta[str(global_id)]['s3_url']
+            camera_image['row'] = camera_grid_positions[name]['row']
+            camera_image['col'] = camera_grid_positions[name]['col']
 
-        # FIXME: Simplify this (see #3)
-        sample = dict()
-        sample["images"] = [
-            fsp_l_struct,
-            rsp_l_struct,
-            lspf_r_struct,
-            lspr_l_struct,
-            rspf_l_struct,
-            rspr_r_struct,
-        ]
+            intrinsics = self.cameras_data[name].calibration_data.intrinsics
+            camera_image['intrinsics']['intrinsic_matrix'] = [
+                [intrinsics.fx, 0.0, intrinsics.cx],
+                [0.0, intrinsics.fy, intrinsics.cy],
+                [0.0, 0.0, 1.0],
+            ]
+            tf = self.cameras_data[name].extrinsics
+            camera_image['extrinsics']['translation'] = {
+                'x': tf.x,
+                'y': tf.y,
+                'z': tf.z,
+            }
 
-        sample["images"][0]["url"] = self.get_cam_url(
-            'fsp_l', sync_key_frame['cameras'], assets_meta
-        )
-        sample["images"][1]["url"] = self.get_cam_url(
-            'rsp_l', sync_key_frame['cameras'], assets_meta
-        )
-        sample["images"][2]["url"] = self.get_cam_url(
-            'lspf_r', sync_key_frame['cameras'], assets_meta
-        )
-        sample["images"][3]["url"] = self.get_cam_url(
-            'lspr_l', sync_key_frame['cameras'], assets_meta
-        )
-        sample["images"][4]["url"] = self.get_cam_url(
-            'rspf_l', sync_key_frame['cameras'], assets_meta
-        )
-        sample["images"][5]["url"] = self.get_cam_url(
-            'rspr_r', sync_key_frame['cameras'], assets_meta
-        )
+            camera_image['extrinsics']['rotation'] = {
+                'qx': tf.qx,
+                'qy': tf.qy,
+                'qz': tf.qz,
+                'qw': tf.qw,
+            }
 
-        return sample["images"]
+            distortion = self.cameras_data[name].calibration_data.distortion
+            camera_image['distortion']['model'] = distortion.model
+            camera_image['distortion']['coefficients'] = {
+                'k1': distortion.k1,
+                'k2': distortion.k2,
+                'k3': distortion.k3,
+                'p1': distortion.p1,
+                'p2': distortion.p2,
+            }
+            camera_image['camera_convention'] = 'OpenCV'
+            camera_image['name'] = "camera_" + name
+
+            images.append(copy.deepcopy(camera_image))
+
+        return images

--- a/scripts/labelling_preproc/common/transform_tree.py
+++ b/scripts/labelling_preproc/common/transform_tree.py
@@ -1,0 +1,176 @@
+"""
+A module to parse a YAML transform tree and compute transforms.
+
+Implement a TransformTree class that replicates the behaviour
+of the ROS 2 TF tree.
+"""
+
+import yaml
+import numpy as np
+from scipy.spatial.transform import Rotation as R
+from collections import defaultdict
+
+
+class Transform:
+    """
+    Represents a rigid transform using translation and quaternion.
+    """
+
+    def __init__(self, matrix: np.ndarray):
+        self._matrix = matrix
+        self.x, self.y, self.z = matrix[:3, 3]
+
+        rot = R.from_matrix(matrix[:3, :3])
+        self.qx, self.qy, self.qz, self.qw = rot.as_quat()
+
+    def matrix(self) -> np.ndarray:
+        """
+        Return the 4x4 homogeneous transformation matrix.
+        """
+        return self._matrix
+
+
+class TransformTree:
+    """
+    Parses a YAML transform tree and resolves frame-to-frame transforms.
+
+    This class replicates ROS 2 TF tree behaviour for querying transforms
+    between any two connected frames in a static transform graph.
+    """
+
+    def __init__(self, yaml_file_path: str):
+        """
+        Load and parse the YAML file containing transforms.
+
+        Args:
+            yaml_file_path: Path to the YAML file.
+        """
+        with open(yaml_file_path) as f:
+            data = yaml.safe_load(f)
+
+        self.transforms = {}
+        self.children = defaultdict(list)
+        self.parents = {}
+
+        for t in data['transforms']:
+            parent = t['parent_frame']
+            child = t['child_frame']
+            tf = t['transform']
+            mat = self._transform_to_matrix(tf)
+
+            self.transforms[(parent, child)] = mat
+            self.transforms[(child, parent)] = np.linalg.inv(mat)
+
+            self.children[parent].append(child)
+            self.parents[child] = parent
+
+    def _transform_to_matrix(self, tf: dict) -> np.ndarray:
+        """
+        Convert a translation + quaternion dict into a 4x4 matrix.
+
+        Args:
+            tf: Dictionary with x, y, z, qx, qy, qz, qw.
+
+        Returns:
+            4x4 numpy array representing the transform.
+        """
+        trans = np.array([tf['x'], tf['y'], tf['z']])
+        quat = np.array([tf['qx'], tf['qy'], tf['qz'], tf['qw']])
+        rot = R.from_quat(quat).as_matrix()
+        mat = np.eye(4)
+        mat[:3, :3] = rot
+        mat[:3, 3] = trans
+        return mat
+
+    def _path_to_root(self, frame: str) -> list[str]:
+        """
+        Return the path from the root to the given frame.
+
+        Args:
+            frame: Frame name to trace upward.
+
+        Returns:
+            List of frames from root to the input frame.
+
+        Raises:
+            KeyError: If the frame is not found.
+        """
+        if frame not in self.parents and frame not in self.children:
+            raise KeyError(f"Frame '{frame}' is not in the tree.")
+
+        path = [frame]
+        current = frame
+        while current in self.parents:
+            current = self.parents[current]
+            path.append(current)
+        return list(reversed(path))
+
+    def _find_common_ancestor(self, path_a: list[str], path_b: list[str]):
+        """
+        Find the deepest shared ancestor between two paths.
+
+        Args:
+            path_a: List of frames from root to target_frame.
+            path_b: List of frames from root to source_frame.
+
+        Returns:
+            Tuple: (common_frame, index_in_a, index_in_b)
+
+        Raises:
+            RuntimeError: If there is no shared ancestor.
+        """
+        min_len = min(len(path_a), len(path_b))
+        last_common = None
+        for i in range(min_len):
+            if path_a[i] != path_b[i]:
+                break
+            last_common = (path_a[i], i, i)
+
+        if last_common is None:
+            raise RuntimeError("No common ancestor found.")
+
+        return last_common
+
+    def get_transform(self, target_frame: str, source_frame: str) -> Transform:
+        """
+        Compute the transform that maps points from source_frame to target_frame.
+
+        Args:
+            target_frame: Target frame name.
+            source_frame: Source frame name.
+
+        Returns:
+            Transform object representing the transform.
+
+        Raises:
+            KeyError: If frames are not connected or unknown.
+        """
+        if target_frame == source_frame:
+            return Transform(np.eye(4))
+
+        path_a = self._path_to_root(target_frame)
+        print(path_a)
+        path_b = self._path_to_root(source_frame)
+        print(path_b)
+
+        common_frame, index_a, index_b = self._find_common_ancestor(
+            path_a, path_b
+        )
+
+        print(f'Common frame: {common_frame}')
+
+        tf_common_to_a = np.eye(4)
+        for i in range(index_a, len(path_a) - 1):
+            parent = path_a[i + 1]
+            child = path_a[i]
+            print(f'Parent: {parent}, Child: {child}')
+            tf_common_to_a = self.transforms[(parent, child)] @ tf_common_to_a
+
+        tf_b_to_common = np.eye(4)
+        for i in range(len(path_b) - 1, index_b, -1):
+            parent = path_b[i - 1]
+            child = path_b[i]
+            print(f'Parent: {parent}, Child: {child}')
+            tf_b_to_common = self.transforms[(parent, child)] @ tf_b_to_common
+
+        return Transform(tf_common_to_a @ tf_b_to_common)

--- a/scripts/labelling_preproc/common/transform_tree.py
+++ b/scripts/labelling_preproc/common/transform_tree.py
@@ -149,28 +149,22 @@ class TransformTree:
             return Transform(np.eye(4))
 
         path_a = self._path_to_root(target_frame)
-        print(path_a)
         path_b = self._path_to_root(source_frame)
-        print(path_b)
 
         common_frame, index_a, index_b = self._find_common_ancestor(
             path_a, path_b
         )
 
-        print(f'Common frame: {common_frame}')
-
         tf_common_to_a = np.eye(4)
         for i in range(index_a, len(path_a) - 1):
             parent = path_a[i + 1]
             child = path_a[i]
-            print(f'Parent: {parent}, Child: {child}')
             tf_common_to_a = self.transforms[(parent, child)] @ tf_common_to_a
 
         tf_b_to_common = np.eye(4)
         for i in range(len(path_b) - 1, index_b, -1):
             parent = path_b[i - 1]
             child = path_b[i]
-            print(f'Parent: {parent}, Child: {child}')
             tf_b_to_common = self.transforms[(parent, child)] @ tf_b_to_common
 
         return Transform(tf_common_to_a @ tf_b_to_common)


### PR DESCRIPTION
- Remove hard-coded camera image dictionaries and obtain the camera's
  Calibration and extrinsic values from the exported data
- Add `camera_calibration_parser` module
  - Obtain intrinsic and distortion values from the exported `camera_calibration.yaml`
    file of each camera
- Update `SensorFrameCreator` to:
  - Extract camera intrinsics and extrinsics from the calibration file
  - Construct SegmentsAI `camera_image` dictionary dynamically,
    replacing hard-coded structs and introducing `camera_image` struct
- Introduce `transform_tree` module
  - Parse a YAML file containing a tree of transformations and
    Provide an interface to apply the transformation for a given
    `target_frame` and `source_frame` pair
 - Install `scipy` in the Docker environment